### PR TITLE
Add "AS tag" in similarity query.

### DIFF
--- a/bioma_llm/sql/similarities.surql
+++ b/bioma_llm/sql/similarities.surql
@@ -2,7 +2,7 @@ SELECT * FROM (
     SELECT
         text,
         vector::similarity::cosine(embedding, $query) AS similarity,
-        id.tag
+        id.tag AS tag
     FROM embedding
 ) WHERE
     (tag IS NONE OR tag = $tag)


### PR DESCRIPTION
Currently, no matter what tag we pass as message, is going to retrieve all of them.

The fix I found is to simply add "AS tag" after the id.tag.

```
SELECT * FROM (
    SELECT
        text,
        vector::similarity::cosine(embedding, $query) AS similarity,
        id.tag AS tag
    FROM embedding
) WHERE
    (tag IS NONE OR tag = $tag)
    AND (similarity > $threshold)
ORDER BY similarity DESC
LIMIT $top_k
```


![image](https://github.com/user-attachments/assets/b710e6f3-b9ef-48e3-bd03-3d1eea0dba50)
