### PR TITLE
Regex for partial retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ curl -X POST http://localhost:5766/index -H "Content-Type: application/json" -d 
 ### Retrieve context:
 
 ```bash
-curl -X POST http://localhost:5766/retrieve -H "Content-Type: application/json" -d '{"query": "Can I make a game with Bioma?", "threshold": 0.0, "limit": 10}'
+curl -X POST http://localhost:5766/retrieve -H "Content-Type: application/json" -d '{"type": "Text", "content": "Can I make a game with Bioma?", "threshold": 0.0, "limit": 10, "sources": ["path/to/specific/source1", ".pdf", ".md"]}'
 ```
 
 ### Ask a question:

--- a/bioma_llm/examples/embeddings.rs
+++ b/bioma_llm/examples/embeddings.rs
@@ -70,6 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         threshold: -0.5,
         k: 5,
         tag: Some("test".to_string()),
+        sources: None,
     };
     info!("Query: {:?}", top_k);
     let similarities =

--- a/bioma_llm/examples/embeddings_image.rs
+++ b/bioma_llm/examples/embeddings_image.rs
@@ -65,6 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         threshold: 0.5,
         k: 3,
         tag: Some("test_images".to_string()),
+        sources: None,
     };
     info!("Image query: {:?}", top_k);
     let similarities =

--- a/bioma_llm/examples/embeddings_pool.rs
+++ b/bioma_llm/examples/embeddings_pool.rs
@@ -105,6 +105,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             threshold: -0.5,
             k: 5,
             tag: Some(format!("test_{}", i)),
+            sources: None,
         };
         info!("Query for actor {}: {:?}", i, top_k);
         let future = relay_ctx.send::<Embeddings, embeddings::TopK>(top_k, embeddings_id, SendOptions::default());

--- a/bioma_llm/examples/rag.rs
+++ b/bioma_llm/examples/rag.rs
@@ -91,7 +91,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Retrieve context
     info!("Retrieving context");
-    let retrieve_context = RetrieveContext { query: RetrieveQuery::Text(query.to_string()), limit: 10, threshold: 0.0 };
+    let retrieve_context =
+        RetrieveContext { query: RetrieveQuery::Text(query.to_string()), limit: 10, threshold: 0.0, sources: None };
     let context = relay_ctx
         .send::<Retriever, RetrieveContext>(
             retrieve_context,

--- a/bioma_llm/examples/rag_server.rs
+++ b/bioma_llm/examples/rag_server.rs
@@ -239,6 +239,7 @@ async fn retrieve(body: web::Json<RetrieveContext>, data: web::Data<AppState>) -
 #[derive(Deserialize)]
 struct ChatQuery {
     messages: Vec<ChatMessage>,
+    sources: Option<Vec<String>>,
 }
 
 async fn chat(body: web::Json<ChatQuery>, data: web::Data<AppState>) -> HttpResponse {
@@ -256,8 +257,12 @@ async fn chat(body: web::Json<ChatQuery>, data: web::Data<AppState>) -> HttpResp
     let retrieved = {
         let mut retriever_ctx = data.retriever_actor.ctx.lock().await;
         let mut retriever_actor = data.retriever_actor.actor.lock().await;
-        let retrieve_context =
-            RetrieveContext { query: RetrieveQuery::Text(query.clone()), limit: 5, threshold: 0.0, sources: None };
+        let retrieve_context = RetrieveContext {
+            query: RetrieveQuery::Text(query.clone()),
+            limit: 5,
+            threshold: 0.0,
+            sources: body.sources.clone(),
+        };
         retriever_actor.handle(&mut retriever_ctx, &retrieve_context).await
     };
 
@@ -346,6 +351,7 @@ async fn chat(body: web::Json<ChatQuery>, data: web::Data<AppState>) -> HttpResp
 #[derive(Deserialize)]
 struct AskQuery {
     query: String,
+    sources: Option<Vec<String>>,
 }
 
 async fn ask(body: web::Json<AskQuery>, data: web::Data<AppState>) -> HttpResponse {
@@ -355,8 +361,12 @@ async fn ask(body: web::Json<AskQuery>, data: web::Data<AppState>) -> HttpRespon
     let retrieved = {
         let mut retriever_ctx = data.retriever_actor.ctx.lock().await;
         let mut retriever_actor = data.retriever_actor.actor.lock().await;
-        let retrieve_context =
-            RetrieveContext { query: RetrieveQuery::Text(body.query.clone()), limit: 5, threshold: 0.0, sources: None };
+        let retrieve_context = RetrieveContext {
+            query: RetrieveQuery::Text(body.query.clone()),
+            limit: 5,
+            threshold: 0.0,
+            sources: body.sources.clone(),
+        };
         retriever_actor.handle(&mut retriever_ctx, &retrieve_context).await
     };
 

--- a/bioma_llm/examples/rag_server.rs
+++ b/bioma_llm/examples/rag_server.rs
@@ -256,7 +256,8 @@ async fn chat(body: web::Json<ChatQuery>, data: web::Data<AppState>) -> HttpResp
     let retrieved = {
         let mut retriever_ctx = data.retriever_actor.ctx.lock().await;
         let mut retriever_actor = data.retriever_actor.actor.lock().await;
-        let retrieve_context = RetrieveContext { query: RetrieveQuery::Text(query.clone()), limit: 5, threshold: 0.0 };
+        let retrieve_context =
+            RetrieveContext { query: RetrieveQuery::Text(query.clone()), limit: 5, threshold: 0.0, sources: None };
         retriever_actor.handle(&mut retriever_ctx, &retrieve_context).await
     };
 
@@ -351,7 +352,7 @@ async fn ask(body: web::Json<AskQuery>, data: web::Data<AppState>) -> HttpRespon
         let mut retriever_ctx = data.retriever_actor.ctx.lock().await;
         let mut retriever_actor = data.retriever_actor.actor.lock().await;
         let retrieve_context =
-            RetrieveContext { query: RetrieveQuery::Text(body.query.clone()), limit: 5, threshold: 0.0 };
+            RetrieveContext { query: RetrieveQuery::Text(body.query.clone()), limit: 5, threshold: 0.0, sources: None };
         retriever_actor.handle(&mut retriever_ctx, &retrieve_context).await
     };
 

--- a/bioma_llm/examples/retriever.rs
+++ b/bioma_llm/examples/retriever.rs
@@ -98,7 +98,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Retrieve context
     info!("Retrieving context");
-    let retrieve_context = RetrieveContext { query: RetrieveQuery::Text(args.query), limit: 10, threshold: 0.0 };
+    let retrieve_context =
+        RetrieveContext { query: RetrieveQuery::Text(args.query), limit: 10, threshold: 0.0, sources: None };
     let context = relay_ctx
         .send::<Retriever, RetrieveContext>(
             retrieve_context,

--- a/bioma_llm/sql/similarities.surql
+++ b/bioma_llm/sql/similarities.surql
@@ -1,17 +1,22 @@
+LET $embeddings = IF array::len($sources) > 0 {
+    // If sources provided, get filtered embeddings
+    RETURN SELECT VALUE out.* 
+    FROM type::table($prefix + "_source_embeddings") 
+    WHERE in.source INSIDE $sources
+} ELSE {
+    // If no sources, get all embeddings
+    RETURN SELECT * FROM type::table($prefix + "_embedding")
+};
+
+// Perform similarity search on either filtered or all embeddings
 SELECT * FROM (
-    SELECT
+    SELECT 
         text,
         vector::similarity::cosine(embedding, $query) AS similarity,
         metadata,
-        id.tag AS tag,
-        <-{prefix}_source_embeddings.in.source AS source
-    FROM type::table($prefix + "_embedding")
-) WHERE
-    (tag IS NONE OR tag = $tag)
-    AND (
-        $sources IS NONE 
-        OR source INSIDE $sources
-    )
+        id.tag AS tag
+    FROM $embeddings
+) WHERE (tag IS NONE OR tag = $tag)
     AND (similarity > $threshold)
 ORDER BY similarity DESC
-LIMIT $top_k
+LIMIT $top_k;

--- a/bioma_llm/sql/similarities.surql
+++ b/bioma_llm/sql/similarities.surql
@@ -1,22 +1,24 @@
 LET $embeddings = IF array::len($sources) > 0 {
     // If sources provided, get filtered embeddings
-    RETURN SELECT VALUE out.* 
-    FROM type::table($prefix + "_source_embeddings") 
-    WHERE in.source INSIDE $sources
+    RETURN SELECT * FROM (
+        SELECT VALUE {
+            text: out.text, 
+            similarity: vector::similarity::cosine(out.embedding, $query),
+            metadata: out.metadata,
+            tag: out.id.tag
+        }
+        FROM type::table($prefix + "_source_embeddings") 
+        WHERE in.source INSIDE $sources
+    ) WHERE (tag IS NONE OR tag = $tag) AND (similarity > $threshold)
 } ELSE {
     // If no sources, get all embeddings
-    RETURN SELECT * FROM type::table($prefix + "_embedding")
+    RETURN SELECT * FROM (
+        SELECT VALUE {
+            text: text,
+            similarity: vector::similarity::cosine(embedding, $query),
+            metadata: metadata,
+            tag: tag
+        } 
+        FROM type::table($prefix + "_embedding")
+    ) WHERE (tag IS NONE OR tag = $tag) AND (similarity > $threshold)
 };
-
-// Perform similarity search on either filtered or all embeddings
-SELECT * FROM (
-    SELECT 
-        text,
-        vector::similarity::cosine(embedding, $query) AS similarity,
-        metadata,
-        id.tag AS tag
-    FROM $embeddings
-) WHERE (tag IS NONE OR tag = $tag)
-    AND (similarity > $threshold)
-ORDER BY similarity DESC
-LIMIT $top_k;

--- a/bioma_llm/sql/similarities.surql
+++ b/bioma_llm/sql/similarities.surql
@@ -3,10 +3,15 @@ SELECT * FROM (
         text,
         vector::similarity::cosine(embedding, $query) AS similarity,
         metadata,
-        id.tag AS tag
+        id.tag AS tag,
+        <-{prefix}_source_embeddings.in.source AS source
     FROM type::table($prefix + "_embedding")
 ) WHERE
     (tag IS NONE OR tag = $tag)
+    AND (
+        $sources IS NONE 
+        OR source INSIDE $sources
+    )
     AND (similarity > $threshold)
 ORDER BY similarity DESC
 LIMIT $top_k

--- a/bioma_llm/sql/similarities.surql
+++ b/bioma_llm/sql/similarities.surql
@@ -1,8 +1,8 @@
 SELECT * FROM (
-    SELECT 
-        out.text,
+    SELECT
+        out.text AS text,
         vector::similarity::cosine(out.embedding, $query) AS similarity,
-        out.metadata,
+        out.metadata AS metadata,
         out.id.tag AS tag
     FROM type::table($prefix + "_source_embeddings")
     WHERE string::matches(in.source, $pattern)

--- a/bioma_llm/sql/similarities.surql
+++ b/bioma_llm/sql/similarities.surql
@@ -1,24 +1,12 @@
-LET $embeddings = IF array::len($sources) > 0 {
-    // If sources provided, get filtered embeddings
-    RETURN SELECT * FROM (
-        SELECT VALUE {
-            text: out.text, 
-            similarity: vector::similarity::cosine(out.embedding, $query),
-            metadata: out.metadata,
-            tag: out.id.tag
-        }
-        FROM type::table($prefix + "_source_embeddings") 
-        WHERE in.source INSIDE $sources
-    ) WHERE (tag IS NONE OR tag = $tag) AND (similarity > $threshold)
-} ELSE {
-    // If no sources, get all embeddings
-    RETURN SELECT * FROM (
-        SELECT VALUE {
-            text: text,
-            similarity: vector::similarity::cosine(embedding, $query),
-            metadata: metadata,
-            tag: tag
-        } 
-        FROM type::table($prefix + "_embedding")
-    ) WHERE (tag IS NONE OR tag = $tag) AND (similarity > $threshold)
-};
+SELECT * FROM (
+    SELECT 
+        out.text,
+        vector::similarity::cosine(out.embedding, $query) AS similarity,
+        out.metadata,
+        out.id.tag AS tag
+    FROM type::table($prefix + "_source_embeddings")
+    WHERE string::matches(in.source, $pattern)
+) WHERE (tag IS NONE OR tag = $tag)
+  AND (similarity > $threshold)
+ORDER BY similarity DESC
+LIMIT $top_k;

--- a/bioma_llm/src/embeddings.rs
+++ b/bioma_llm/src/embeddings.rs
@@ -206,7 +206,9 @@ impl Message<TopK> for Embeddings {
             .bind(("prefix", self.table_prefix()))
             .await
             .map_err(SystemActorError::from)?;
+        println!("results: {:?}", results);
         let results: Result<Vec<Similarity>, _> = results.take(0).map_err(SystemActorError::from);
+        println!("Similarity results: {:?}", results);
         results.map_err(EmbeddingsError::from)
     }
 }

--- a/bioma_llm/src/embeddings.rs
+++ b/bioma_llm/src/embeddings.rs
@@ -100,6 +100,8 @@ pub struct TopK {
     pub query: Query,
     /// The tag to filter the embeddings by
     pub tag: Option<String>,
+    /// The sources to filter by
+    pub sources: Option<Vec<String>>,
     /// Number of similar embeddings to return
     pub k: usize,
     /// The threshold for the similarity score
@@ -195,6 +197,7 @@ impl Message<TopK> for Embeddings {
             .bind(("query", query_embedding))
             .bind(("top_k", message.k.clone()))
             .bind(("tag", message.tag.clone()))
+            .bind(("sources", message.sources.clone()))
             .bind(("threshold", message.threshold))
             .bind(("prefix", self.table_name_prefix.clone()))
             .await

--- a/bioma_llm/src/embeddings.rs
+++ b/bioma_llm/src/embeddings.rs
@@ -206,9 +206,7 @@ impl Message<TopK> for Embeddings {
             .bind(("prefix", self.table_prefix()))
             .await
             .map_err(SystemActorError::from)?;
-        println!("results: {:?}", results);
         let results: Result<Vec<Similarity>, _> = results.take(0).map_err(SystemActorError::from);
-        println!("Similarity results: {:?}", results);
         results.map_err(EmbeddingsError::from)
     }
 }

--- a/bioma_llm/src/embeddings.rs
+++ b/bioma_llm/src/embeddings.rs
@@ -207,9 +207,7 @@ impl Message<TopK> for Embeddings {
             .bind(("prefix", self.table_name_prefix.clone()))
             .await
             .map_err(SystemActorError::from)?;
-        println!("Results: {:#?}", results);
         let results: Result<Vec<Similarity>, _> = results.take(0).map_err(SystemActorError::from);
-        println!("Similatity Results: {:#?}", results);
         results.map_err(EmbeddingsError::from)
     }
 }

--- a/bioma_llm/src/retriever.rs
+++ b/bioma_llm/src/retriever.rs
@@ -46,6 +46,8 @@ pub struct RetrieveContext {
     #[builder(default = DEFAULT_RETRIEVER_THRESHOLD)]
     #[serde(default = "default_retriever_threshold")]
     pub threshold: f32,
+    #[serde(default)]
+    pub sources: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -145,6 +147,7 @@ impl Message<RetrieveContext> for Retriever {
                     k: message.limit * 2,
                     threshold: message.threshold,
                     tag: Some(self.tag.clone().to_string()),
+                    sources: message.sources.clone(),
                 };
 
                 info!("Searching for similarities");

--- a/bioma_llm/tests/embeddings.rs
+++ b/bioma_llm/tests/embeddings.rs
@@ -889,7 +889,8 @@ async fn test_embeddings_source_filtering() -> Result<(), TestError> {
     assert!(!similarities.is_empty());
     for similarity in &similarities {
         assert!(
-            similarity.text.as_ref().unwrap().contains("document 1"),
+            similarity.text.as_ref().unwrap().contains("document 1")
+                || similarity.text.as_ref().unwrap().contains("doc 1"),
             "Expected only results from document1.pdf, got: {}",
             similarity.text.as_ref().unwrap()
         );
@@ -912,7 +913,9 @@ async fn test_embeddings_source_filtering() -> Result<(), TestError> {
     for similarity in &similarities {
         assert!(
             similarity.text.as_ref().unwrap().contains("document 1")
-                || similarity.text.as_ref().unwrap().contains("document 2"),
+                || similarity.text.as_ref().unwrap().contains("doc 1")
+                || similarity.text.as_ref().unwrap().contains("document 2")
+                || similarity.text.as_ref().unwrap().contains("doc 2"),
             "Expected only results from document1.pdf or document2.pdf, got: {}",
             similarity.text.as_ref().unwrap()
         );
@@ -934,13 +937,14 @@ async fn test_embeddings_source_filtering() -> Result<(), TestError> {
     assert!(similarities.len() > 4); // Should get results from all documents
     let mut found_sources = vec![false, false, false]; // Track which documents we found
     for similarity in &similarities {
-        if similarity.text.as_ref().unwrap().contains("document 1") {
+        let text = similarity.text.as_ref().unwrap();
+        if text.contains("document 1") || text.contains("doc 1") {
             found_sources[0] = true;
         }
-        if similarity.text.as_ref().unwrap().contains("document 2") {
+        if text.contains("document 2") || text.contains("doc 2") {
             found_sources[1] = true;
         }
-        if similarity.text.as_ref().unwrap().contains("document 3") {
+        if text.contains("document 3") || text.contains("doc 3") {
             found_sources[2] = true;
         }
     }


### PR DESCRIPTION
### Features
- Added `sources` field to `RetrieveContext` for filtering specific sources.
- Defaults to querying all sources if none specified.
- Combines specified sources into a regex (e.g., `[".pdf", ".jpg"]` -> `".pdf|.jpg"`).

### Testing
- Added test: `test_embeddings_regex_source_filtering`.
  - Run with:  
    ```sh
    cargo test --package bioma_llm --test embeddings -- test_embeddings_regex_source_filtering --exact --show-output
    ```