### PR TITLE
Optimize Similarities Search

### DIFF
--- a/bioma_llm/sql/def.surql
+++ b/bioma_llm/sql/def.surql
@@ -6,15 +6,6 @@ DEFINE FIELD name ON model TYPE string PERMISSIONS FULL;
 DEFINE TABLE {prefix}_embedding TYPE NORMAL SCHEMALESS PERMISSIONS NONE;
 DEFINE FIELD text ON {prefix}_embedding TYPE option<string> PERMISSIONS FULL;
 DEFINE FIELD embedding ON {prefix}_embedding TYPE array<number> PERMISSIONS FULL;
--- TODO: Delete if not gonna perform queries directly on the embedding table
-DEFINE INDEX {prefix}_embedding_index ON TABLE {prefix}_embedding 
-    FIELDS embedding MTREE DIMENSION {dim} DIST COSINE 
-    TYPE F32 CAPACITY 40 DOC_IDS_ORDER 1000 DOC_IDS_CACHE 2000 MTREE_CACHE 2000;
-
--- Index on embedding id for efficient filtered lookups
--- Used by query planner to iterate specific records rather than full table scans
--- Critical for performance when filtering embeddings by IDs before vector similarity search
-DEFINE INDEX {prefix}_embedding_id_idx ON {prefix}_embedding FIELDS id;
 
 -- Add Full-Text Search index for the embedding text field
 DEFINE ANALYZER custom_analyzer TOKENIZERS blank FILTERS lowercase, snowball(english);

--- a/bioma_llm/sql/def.surql
+++ b/bioma_llm/sql/def.surql
@@ -14,7 +14,6 @@ DEFINE INDEX {prefix}_embedding_text_search ON {prefix}_embedding FIELDS text SE
 -- Define the source table
 DEFINE TABLE source TYPE NORMAL SCHEMALESS PERMISSIONS NONE;
 DEFINE FIELD summary ON source TYPE option<string> PERMISSIONS FULL;
--- TODO: Delete if not gonna perform queries directly on the source table
 DEFINE INDEX source_idx ON source FIELDS id.source;
 -- DEFINE FIELD source ON source TYPE string PERMISSIONS FULL;
 -- DEFINE FIELD uri ON source TYPE string PERMISSIONS FULL;

--- a/bioma_llm/sql/def.surql
+++ b/bioma_llm/sql/def.surql
@@ -6,6 +6,7 @@ DEFINE FIELD name ON model TYPE string PERMISSIONS FULL;
 DEFINE TABLE {prefix}_embedding TYPE NORMAL SCHEMALESS PERMISSIONS NONE;
 DEFINE FIELD text ON {prefix}_embedding TYPE option<string> PERMISSIONS FULL;
 DEFINE FIELD embedding ON {prefix}_embedding TYPE array<number> PERMISSIONS FULL;
+-- TODO: Delete if not gonna perform queries directly on the embedding table
 DEFINE INDEX {prefix}_embedding_index ON TABLE {prefix}_embedding 
     FIELDS embedding MTREE DIMENSION {dim} DIST COSINE 
     TYPE F32 CAPACITY 40 DOC_IDS_ORDER 1000 DOC_IDS_CACHE 2000 MTREE_CACHE 2000;
@@ -22,6 +23,7 @@ DEFINE INDEX {prefix}_embedding_text_search ON {prefix}_embedding FIELDS text SE
 -- Define the source table
 DEFINE TABLE source TYPE NORMAL SCHEMALESS PERMISSIONS NONE;
 DEFINE FIELD summary ON source TYPE option<string> PERMISSIONS FULL;
+-- TODO: Delete if not gonna perform queries directly on the source table
 DEFINE INDEX source_idx ON source FIELDS id.source;
 -- DEFINE FIELD source ON source TYPE string PERMISSIONS FULL;
 -- DEFINE FIELD uri ON source TYPE string PERMISSIONS FULL;
@@ -31,8 +33,14 @@ DEFINE INDEX source_idx ON source FIELDS id.source;
 DEFINE TABLE {prefix}_source_embeddings TYPE RELATION IN source OUT {prefix}_embedding SCHEMALESS PERMISSIONS NONE;
 DEFINE FIELD in ON {prefix}_source_embeddings TYPE record<source> PERMISSIONS FULL;
 DEFINE FIELD out ON {prefix}_source_embeddings TYPE record<{prefix}_embedding> PERMISSIONS FULL;
--- DEFINE INDEX {prefix}_source_embeddings_in_idx ON TABLE {prefix}_source_embeddings FIELDS in;
--- DEFINE INDEX {prefix}_source_embeddings_source_idx ON TABLE {prefix}_source_embeddings FIELDS in.source;
+-- Optimizes filtering by source in relation queries
+-- Critical for performant source-based filtering when querying directly from the relation table
+-- Used heavily in similarity searches that need to scope results to specific sources
+DEFINE INDEX {prefix}_source_embeddings_in_id_source_index ON {prefix}_source_embeddings FIELDS in.id.source;
+-- Optimizes vector similarity searches directly on the relation table
+-- Allows efficient vector similarity operations without having to join with the embedding table
+-- Enables querying embeddings by similarity while filtering by source in a single operation
+DEFINE INDEX {prefix}_source_embeddings_out_embedding_index ON {prefix}_source_embeddings FIELDS out.embedding MTREE DIMENSION {dim} DIST COSINE TYPE F32 CAPACITY 40 DOC_IDS_ORDER 1000 DOC_IDS_CACHE 2000 MTREE_CACHE 2000;
 
 -- Define the model_embeddings table
 DEFINE TABLE {prefix}_model_embeddings TYPE RELATION IN model OUT {prefix}_embedding SCHEMALESS PERMISSIONS NONE;

--- a/bioma_llm/sql/del_source.surql
+++ b/bioma_llm/sql/del_source.surql
@@ -1,4 +1,3 @@
--- TODO: We need to reevaluate our approach to deleting sources with the new indexes on the relation tables.
 BEGIN;
 
 -- Get all sources matching the exact source IDs

--- a/bioma_llm/sql/del_source.surql
+++ b/bioma_llm/sql/del_source.surql
@@ -1,3 +1,4 @@
+-- TODO: We need to reevaluate our approach to deleting sources with the new indexes on the relation tables.
 BEGIN;
 
 -- Get all sources matching the exact source IDs

--- a/bioma_llm/sql/similarities.surql
+++ b/bioma_llm/sql/similarities.surql
@@ -1,19 +1,12 @@
--- Get filtered sources
-LET $filtered_ids = array::flatten((
-    SELECT VALUE ->{prefix}_source_embeddings.out.id 
-    FROM source
-    WHERE id.source IN $sources
-));
-
--- Get the top k most similar embeddings to the query from the filtered IDs
+-- Get the top k most similar embeddings for each source
 SELECT 
-    id,
-    text,
-    vector::similarity::cosine(embedding, $query) AS similarity,
-    metadata,
-    <-{prefix}_source_embeddings.in[0].id.{source, uri} AS source
-FROM type::table($prefix + "_embedding")
+    out.id AS id,
+    out.text AS text,
+    vector::similarity::cosine(out.embedding, $query) AS similarity,
+    out.metadata as metadata,
+    in.id.{source, uri} AS source
+FROM type::table($prefix + "_source_embeddings")
 WHERE 
-    id IN $filtered_ids
-    AND embedding <|{top_k}|> $query
+    in.id.source IN $sources
+    AND out.embedding <|{top_k}|> $query
 ORDER BY similarity DESC;

--- a/bioma_llm/src/embeddings.rs
+++ b/bioma_llm/src/embeddings.rs
@@ -304,7 +304,7 @@ impl Message<TopK> for Embeddings {
             .bind(("prefix", self.table_prefix()))
             .await
             .map_err(SystemActorError::from)?;
-        let results: Vec<Similarity> = results.take(1).map_err(SystemActorError::from)?;
+        let results: Vec<Similarity> = results.take(0).map_err(SystemActorError::from)?;
         ctx.reply(results).await?;
         Ok(())
     }


### PR DESCRIPTION
1. Create indexes directly on {prefix}_source_embeddings.
2. Change similarities.surql query to query directly from that table making use of the indexes created for such table.