### PR TITLE
Generation Options Available in RAG Server API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,7 +937,7 @@ dependencies = [
  "serde_json",
  "surrealdb",
  "test-log",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -962,7 +962,7 @@ dependencies = [
  "serde_json",
  "surrealdb",
  "test-log",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1007,7 +1007,7 @@ dependencies = [
  "tempfile",
  "test-log",
  "text-splitter",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1051,7 +1051,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.26.2",
@@ -1571,7 +1571,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2081,7 +2081,7 @@ dependencies = [
  "serde_json",
  "serenity",
  "text-splitter",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2897,7 +2897,7 @@ dependencies = [
  "reqwest 0.12.12",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ureq",
  "windows-sys 0.59.0",
 ]
@@ -4387,8 +4387,8 @@ dependencies = [
 
 [[package]]
 name = "ollama-rs"
-version = "0.2.5"
-source = "git+https://github.com/VertexStudio/ollama-rs.git?rev=d3e45ff4ebad353f3abe88f2c1a3fdb6fa525b15#d3e45ff4ebad353f3abe88f2c1a3fdb6fa525b15"
+version = "0.2.6"
+source = "git+https://github.com/VertexStudio/ollama-rs.git?rev=047bea58f3a6ee009c3948e676ec2321dcfa24a8#047bea58f3a6ee009c3948e676ec2321dcfa24a8"
 dependencies = [
  "async-stream",
  "log",
@@ -4397,7 +4397,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "url",
@@ -4611,7 +4611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -5028,7 +5028,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.23",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -5047,7 +5047,7 @@ dependencies = [
  "rustls 0.23.23",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5252,7 +5252,7 @@ dependencies = [
  "log",
  "markup5ever_rcdom 0.2.0",
  "regex",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "url",
 ]
 
@@ -6191,7 +6191,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -6849,7 +6849,7 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "regex",
  "strum",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tree-sitter",
  "unicode-segmentation",
 ]
@@ -6865,11 +6865,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -6885,9 +6885,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7484,7 +7484,7 @@ dependencies = [
  "log",
  "rand 0.9.0",
  "sha1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "utf-8",
 ]
 
@@ -8494,7 +8494,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.8.5",
  "sha1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "zeroize",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ schemars = "0.8"
 bon = "3.1"
 
 # Error Handling and Utilities
-thiserror = "2.0"
+thiserror = "2.0.12"
 anyhow = "1.0"
 derive_more = "0.99"
 
@@ -112,7 +112,7 @@ regex = "1.11"
 #     "function-calling",
 #     "stream",
 # ] }
-ollama-rs = { git = "https://github.com/VertexStudio/ollama-rs.git", rev = "d3e45ff4ebad353f3abe88f2c1a3fdb6fa525b15", features = [
+ollama-rs = { git = "https://github.com/VertexStudio/ollama-rs.git", rev = "047bea58f3a6ee009c3948e676ec2321dcfa24a8", features = [
     "stream",
     "utoipa",
 ] }

--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ curl -X 'POST' \
                     "content": "Why is the sky blue?"
                 }
             ],
-            "sources": ["/bioma"]
+            "sources": ["/bioma"],
+            "context_length": 4096
     }'
 ```
 
@@ -292,7 +293,8 @@ curl -X POST http://localhost:5766/chat \
                 "role": "user",
                 "content": "Why is the sky blue?"
             }
-        ]
+        ],
+        "context_length": 4096
     }'
 ```
 
@@ -310,6 +312,7 @@ curl -X POST http://localhost:5766/ask \
                 "content": "Tell me about Puerto Rico."
             }
         ],
+        "context_length": 4096,
         "format": {
             "title": "PuertoRicoInfo",
             "type": "object",

--- a/README.md
+++ b/README.md
@@ -276,7 +276,12 @@ curl -X 'POST' \
                 }
             ],
             "sources": ["/bioma"],
-            "context_length": 4096
+            "options": {
+                "temperature": 0.7,
+                "top_p": 0.95,
+                "num_predict": 1024,
+                "num_ctx": 4096
+            }
     }'
 ```
 
@@ -294,7 +299,12 @@ curl -X POST http://localhost:5766/chat \
                 "content": "Why is the sky blue?"
             }
         ],
-        "context_length": 4096
+        "options": {
+            "temperature": 0.7,
+            "top_p": 0.95,
+            "num_predict": 1024,
+            "num_ctx": 4096
+        }
     }'
 ```
 
@@ -312,7 +322,12 @@ curl -X POST http://localhost:5766/ask \
                 "content": "Tell me about Puerto Rico."
             }
         ],
-        "context_length": 4096,
+        "options": {
+            "temperature": 0.2,
+            "top_p": 0.9,
+            "num_predict": 2048,
+            "num_ctx": 4096
+        },
         "format": {
             "title": "PuertoRicoInfo",
             "type": "object",

--- a/assets/configs/rag_config_server.json
+++ b/assets/configs/rag_config_server.json
@@ -17,8 +17,8 @@
   "summary_text_prompt": "Provide a concise summary of the following text. Focus on the key points and main ideas:\n\n",
   "summary_image_prompt": "Provide a concise description of this image. Focus on the key visual elements, subjects, and overall composition.",
   "chat_messages_limit": 10,
-  "chat_context_length": 4096,
+  "chat_max_context_length": 4096,
   "think_messages_limit": 10,
-  "think_context_length": 4096,
+  "think_max_context_length": 4096,
   "retrieve_limit": 5
 }

--- a/bioma_llm/src/chat.rs
+++ b/bioma_llm/src/chat.rs
@@ -161,17 +161,8 @@ impl Message<ChatMessages> for Chat {
         }
 
         // Add generation options
-        chat_message_request = chat_message_request.options(self.generation_options.clone());
-
-        if request.context_length < self.max_context_length {
-            println!("Setting context length to {}", request.context_length);
-            chat_message_request =
-                chat_message_request.options(self.generation_options.clone().num_ctx(request.context_length));
-        } else {
-            println!("Setting context length to {}", self.max_context_length);
-            chat_message_request =
-                chat_message_request.options(self.generation_options.clone().num_ctx(self.max_context_length));
-        }
+        let context_length = std::cmp::min(request.context_length, self.max_context_length);
+        chat_message_request = chat_message_request.options(self.generation_options.clone().num_ctx(context_length));
 
         // Add format
         if let Some(format) = &request.format {

--- a/bioma_llm/src/chat.rs
+++ b/bioma_llm/src/chat.rs
@@ -16,10 +16,6 @@ use std::borrow::Cow;
 use tracing::{error, info};
 use url::Url;
 
-const DEFAULT_MODEL_NAME: &str = "llama3.2";
-const DEFAULT_ENDPOINT: &str = "http://localhost:11434";
-const DEFAULT_MESSAGES_NUMBER_LIMIT: usize = 10;
-
 /// Enumerates the types of errors that can occur in LLM
 #[derive(thiserror::Error, Debug)]
 pub enum ChatError {
@@ -55,18 +51,37 @@ impl ActorError for ChatError {}
 
 #[derive(bon::Builder, Debug, Clone, Serialize, Deserialize)]
 pub struct Chat {
-    #[builder(default = DEFAULT_MODEL_NAME.into())]
+    #[builder(default = default_model_name())]
     pub model: Cow<'static, str>,
-    pub generation_options: Option<GenerationOptions>,
-    #[builder(default = Url::parse(DEFAULT_ENDPOINT).unwrap())]
+    #[builder(default)]
+    pub generation_options: GenerationOptions,
+    #[builder(default = default_endpoint())]
     pub endpoint: Url,
-    #[builder(default = DEFAULT_MESSAGES_NUMBER_LIMIT)]
+    #[builder(default = default_messages_number_limit())]
     pub messages_number_limit: usize,
     #[builder(default)]
     pub history: Vec<ChatMessage>,
+    #[builder(default = default_max_context_length())]
+    pub max_context_length: u32,
     #[serde(skip)]
     #[builder(default)]
     ollama: Ollama,
+}
+
+fn default_model_name() -> Cow<'static, str> {
+    "llama3.2:3b".into()
+}
+
+fn default_endpoint() -> Url {
+    Url::parse("http://localhost:11434").unwrap()
+}
+
+fn default_messages_number_limit() -> usize {
+    10
+}
+
+fn default_max_context_length() -> u32 {
+    4096
 }
 
 impl Default for Chat {
@@ -109,6 +124,12 @@ pub struct ChatMessages {
     pub stream: bool,
     pub format: Option<Schema>,
     pub tools: Option<Vec<ToolInfo>>,
+    #[builder(default = default_context_length())]
+    pub context_length: u32,
+}
+
+fn default_context_length() -> u32 {
+    4096
 }
 
 impl Message<ChatMessages> for Chat {
@@ -140,8 +161,16 @@ impl Message<ChatMessages> for Chat {
         }
 
         // Add generation options
-        if let Some(generation_options) = &self.generation_options {
-            chat_message_request = chat_message_request.options(generation_options.clone());
+        chat_message_request = chat_message_request.options(self.generation_options.clone());
+
+        if request.context_length < self.max_context_length {
+            println!("Setting context length to {}", request.context_length);
+            chat_message_request =
+                chat_message_request.options(self.generation_options.clone().num_ctx(request.context_length));
+        } else {
+            println!("Setting context length to {}", self.max_context_length);
+            chat_message_request =
+                chat_message_request.options(self.generation_options.clone().num_ctx(self.max_context_length));
         }
 
         // Add format

--- a/tools/cognition/src/api_schema.rs
+++ b/tools/cognition/src/api_schema.rs
@@ -39,7 +39,7 @@ pub struct ChatQuery {
     pub stream: bool,
 
     /// The maximum context length for this chat query
-    #[serde(default = "default_chat_max_context_length")]
+    #[serde(default = "default_chat_context_length")]
     pub context_length: u32,
 }
 
@@ -47,7 +47,7 @@ fn default_chat_stream() -> bool {
     true
 }
 
-fn default_chat_max_context_length() -> u32 {
+fn default_chat_context_length() -> u32 {
     4096
 }
 
@@ -78,7 +78,7 @@ pub struct ThinkQuery {
     pub stream: bool,
 
     /// The maximum context length for this think query
-    #[serde(default = "default_think_max_context_length")]
+    #[serde(default = "default_think_context_length")]
     pub context_length: u32,
 }
 
@@ -86,7 +86,7 @@ fn default_think_stream() -> bool {
     true
 }
 
-fn default_think_max_context_length() -> u32 {
+fn default_think_context_length() -> u32 {
     4096
 }
 
@@ -105,11 +105,11 @@ pub struct AskQuery {
     pub format: Option<chat::Schema>,
 
     /// The maximum context length for this ask query
-    #[serde(default = "default_ask_max_context_length")]
+    #[serde(default = "default_ask_context_length")]
     pub context_length: u32,
 }
 
-fn default_ask_max_context_length() -> u32 {
+fn default_ask_context_length() -> u32 {
     4096
 }
 

--- a/tools/cognition/src/api_schema.rs
+++ b/tools/cognition/src/api_schema.rs
@@ -37,10 +37,18 @@ pub struct ChatQuery {
     /// Whether to stream the response
     #[serde(default = "default_chat_stream")]
     pub stream: bool,
+
+    /// The maximum context length for this chat query
+    #[serde(default = "default_chat_max_context_length")]
+    pub context_length: u32,
 }
 
 fn default_chat_stream() -> bool {
     true
+}
+
+fn default_chat_max_context_length() -> u32 {
+    4096
 }
 
 /// Request schema for think operation
@@ -68,10 +76,18 @@ pub struct ThinkQuery {
     /// Whether to stream the response
     #[serde(default = "default_think_stream")]
     pub stream: bool,
+
+    /// The maximum context length for this think query
+    #[serde(default = "default_think_max_context_length")]
+    pub context_length: u32,
 }
 
 fn default_think_stream() -> bool {
     true
+}
+
+fn default_think_max_context_length() -> u32 {
+    4096
 }
 
 /// Request schema for asking a question
@@ -87,6 +103,14 @@ pub struct AskQuery {
 
     /// Optional schema for structured output format
     pub format: Option<chat::Schema>,
+
+    /// The maximum context length for this ask query
+    #[serde(default = "default_ask_max_context_length")]
+    pub context_length: u32,
+}
+
+fn default_ask_max_context_length() -> u32 {
+    4096
 }
 
 //------------------------------------------------------------------------------

--- a/tools/cognition/src/api_schema.rs
+++ b/tools/cognition/src/api_schema.rs
@@ -5,7 +5,7 @@ use bioma_llm::{
     prelude::{ChatMessage, GlobsContent, Index, IndexContent, RetrieveContext, RetrieveQuery, TextChunkConfig},
     retriever::{default_retriever_limit, default_retriever_sources, default_retriever_threshold},
 };
-use ollama_rs::generation::tools::ToolInfo;
+use ollama_rs::{generation::tools::ToolInfo, models::ModelOptions};
 use serde::{Deserialize, Serialize};
 
 //------------------------------------------------------------------------------
@@ -38,17 +38,12 @@ pub struct ChatQuery {
     #[serde(default = "default_chat_stream")]
     pub stream: bool,
 
-    /// The maximum context length for this chat query
-    #[serde(default = "default_chat_context_length")]
-    pub context_length: u32,
+    /// Generation options
+    pub options: Option<ModelOptions>,
 }
 
 fn default_chat_stream() -> bool {
     true
-}
-
-fn default_chat_context_length() -> u32 {
-    4096
 }
 
 /// Request schema for think operation
@@ -77,17 +72,12 @@ pub struct ThinkQuery {
     #[serde(default = "default_think_stream")]
     pub stream: bool,
 
-    /// The maximum context length for this think query
-    #[serde(default = "default_think_context_length")]
-    pub context_length: u32,
+    /// Generation options
+    pub options: Option<ModelOptions>,
 }
 
 fn default_think_stream() -> bool {
     true
-}
-
-fn default_think_context_length() -> u32 {
-    4096
 }
 
 /// Request schema for asking a question
@@ -104,13 +94,8 @@ pub struct AskQuery {
     /// Optional schema for structured output format
     pub format: Option<chat::Schema>,
 
-    /// The maximum context length for this ask query
-    #[serde(default = "default_ask_context_length")]
-    pub context_length: u32,
-}
-
-fn default_ask_context_length() -> u32 {
-    4096
+    /// Generation options
+    pub options: Option<ModelOptions>,
 }
 
 //------------------------------------------------------------------------------

--- a/tools/cognition/src/lib.rs
+++ b/tools/cognition/src/lib.rs
@@ -60,6 +60,7 @@ pub async fn chat_with_tools(
     tx: tokio::sync::mpsc::Sender<Result<Json<ChatResponse>, String>>,
     format: Option<chat::Schema>,
     stream: bool,
+    context_length: u32,
     first_token_sent: std::sync::Arc<std::sync::atomic::AtomicBool>,
     request_start_time: std::time::Instant,
 ) -> Result<(), ChatToolError> {
@@ -71,6 +72,7 @@ pub async fn chat_with_tools(
         stream,
         format: format.clone(),
         tools: if tools.is_empty() { None } else { Some(tools.clone()) },
+        context_length,
     };
 
     info!("chat_with_tools: {} tools, {} messages, actor: {}", tools.len(), messages.len(), chat_actor);
@@ -144,6 +146,7 @@ pub async fn chat_with_tools(
                         tx.clone(),
                         format.clone(),
                         stream,
+                        context_length,
                         first_token_sent.clone(),
                         request_start_time,
                     ))

--- a/tools/cognition/src/lib.rs
+++ b/tools/cognition/src/lib.rs
@@ -3,9 +3,12 @@ use std::collections::HashMap;
 use actix_web::web::Json;
 use bioma_actor::prelude::*;
 use bioma_llm::prelude::*;
-use ollama_rs::generation::{
-    chat::ChatMessageResponse,
-    tools::{ToolCall, ToolInfo},
+use ollama_rs::{
+    generation::{
+        chat::ChatMessageResponse,
+        tools::{ToolCall, ToolInfo},
+    },
+    models::ModelOptions,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -60,7 +63,7 @@ pub async fn chat_with_tools(
     tx: tokio::sync::mpsc::Sender<Result<Json<ChatResponse>, String>>,
     format: Option<chat::Schema>,
     stream: bool,
-    context_length: u32,
+    options: Option<ModelOptions>,
     first_token_sent: std::sync::Arc<std::sync::atomic::AtomicBool>,
     request_start_time: std::time::Instant,
 ) -> Result<(), ChatToolError> {
@@ -72,7 +75,7 @@ pub async fn chat_with_tools(
         stream,
         format: format.clone(),
         tools: if tools.is_empty() { None } else { Some(tools.clone()) },
-        context_length,
+        options: options.clone(),
     };
 
     info!("chat_with_tools: {} tools, {} messages, actor: {}", tools.len(), messages.len(), chat_actor);
@@ -146,7 +149,7 @@ pub async fn chat_with_tools(
                         tx.clone(),
                         format.clone(),
                         stream,
-                        context_length,
+                        options.clone(),
                         first_token_sent.clone(),
                         request_start_time,
                     ))

--- a/tools/cognition/src/server.rs
+++ b/tools/cognition/src/server.rs
@@ -769,7 +769,7 @@ async fn chat(body: web::Json<ChatQuery>, data: web::Data<AppState>) -> HttpResp
             "/rag/chat",
             data.config.chat_model.clone(),
             data.config.chat_messages_limit,
-            data.config.chat_context_length,
+            data.config.chat_max_context_length,
         )
         .await
     {
@@ -945,6 +945,7 @@ async fn chat(body: web::Json<ChatQuery>, data: web::Data<AppState>) -> HttpResp
                                 stream: false,
                                 format: body.format.clone(),
                                 tools: Some(client_tools),
+                                context_length: body.context_length,
                             },
                             &chat_id,
                             SendOptions::builder().timeout(std::time::Duration::from_secs(600)).build(),
@@ -1022,6 +1023,7 @@ async fn chat(body: web::Json<ChatQuery>, data: web::Data<AppState>) -> HttpResp
                     chat_with_tools_tx,
                     body.format.clone(),
                     body.stream,
+                    body.context_length,
                     first_token_sent_tools,
                     request_start_time_tools,
                 )
@@ -1219,7 +1221,7 @@ async fn think(body: web::Json<ThinkQuery>, data: web::Data<AppState>) -> HttpRe
             "/rag/think",
             data.config.think_model.clone(),
             data.config.think_messages_limit,
-            data.config.think_context_length,
+            data.config.think_max_context_length,
         )
         .await
     {
@@ -1437,6 +1439,7 @@ async fn think(body: web::Json<ThinkQuery>, data: web::Data<AppState>) -> HttpRe
             stream: body.stream,
             format: body.format.clone(),
             tools: None,
+            context_length: body.context_length,
         };
 
         let mut chat_response = match user_actor
@@ -1637,7 +1640,7 @@ async fn ask(body: web::Json<AskQuery>, data: web::Data<AppState>) -> HttpRespon
             "/rag/ask",
             data.config.chat_model.clone(),
             data.config.chat_messages_limit,
-            data.config.chat_context_length,
+            data.config.chat_max_context_length,
         )
         .await
     {
@@ -1781,6 +1784,7 @@ async fn ask(body: web::Json<AskQuery>, data: web::Data<AppState>) -> HttpRespon
                         stream: false,
                         format: body.format.clone(),
                         tools: None,
+                        context_length: body.context_length,
                     },
                     &chat_id,
                     SendOptions::builder().timeout(std::time::Duration::from_secs(600)).build(),

--- a/tools/cognition/src/server_config.rs
+++ b/tools/cognition/src/server_config.rs
@@ -30,11 +30,11 @@ pub struct ServerConfig {
     #[serde(default = "default_chat_messages_limit")]
     pub chat_messages_limit: usize,
     #[serde(default = "default_chat_max_context_length")]
-    pub chat_max_context_length: u32,
+    pub chat_max_context_length: u64,
     #[serde(default = "default_think_messages_limit")]
     pub think_messages_limit: usize,
     #[serde(default = "default_think_max_context_length")]
-    pub think_max_context_length: u32,
+    pub think_max_context_length: u64,
     #[serde(default = "default_retrieve_limit")]
     pub retrieve_limit: usize,
 }
@@ -107,7 +107,7 @@ fn default_chat_messages_limit() -> usize {
     10
 }
 
-fn default_chat_max_context_length() -> u32 {
+fn default_chat_max_context_length() -> u64 {
     4096
 }
 
@@ -115,7 +115,7 @@ fn default_think_messages_limit() -> usize {
     10
 }
 
-fn default_think_max_context_length() -> u32 {
+fn default_think_max_context_length() -> u64 {
     4096
 }
 

--- a/tools/cognition/src/server_config.rs
+++ b/tools/cognition/src/server_config.rs
@@ -29,12 +29,12 @@ pub struct ServerConfig {
     pub summary_image_prompt: Cow<'static, str>,
     #[serde(default = "default_chat_messages_limit")]
     pub chat_messages_limit: usize,
-    #[serde(default = "default_chat_context_length")]
-    pub chat_context_length: u32,
+    #[serde(default = "default_chat_max_context_length")]
+    pub chat_max_context_length: u32,
     #[serde(default = "default_think_messages_limit")]
     pub think_messages_limit: usize,
-    #[serde(default = "default_think_context_length")]
-    pub think_context_length: u32,
+    #[serde(default = "default_think_max_context_length")]
+    pub think_max_context_length: u32,
     #[serde(default = "default_retrieve_limit")]
     pub retrieve_limit: usize,
 }
@@ -107,7 +107,7 @@ fn default_chat_messages_limit() -> usize {
     10
 }
 
-fn default_chat_context_length() -> u32 {
+fn default_chat_max_context_length() -> u32 {
     4096
 }
 
@@ -115,7 +115,7 @@ fn default_think_messages_limit() -> usize {
     10
 }
 
-fn default_think_context_length() -> u32 {
+fn default_think_max_context_length() -> u32 {
     4096
 }
 
@@ -136,9 +136,9 @@ impl Default for ServerConfig {
             summary_text_prompt: default_summary_text_prompt(),
             summary_image_prompt: default_summary_image_prompt(),
             chat_messages_limit: default_chat_messages_limit(),
-            chat_context_length: default_chat_context_length(),
+            chat_max_context_length: default_chat_max_context_length(),
             think_messages_limit: default_think_messages_limit(),
-            think_context_length: default_think_context_length(),
+            think_max_context_length: default_think_max_context_length(),
             retrieve_limit: default_retrieve_limit(),
         }
     }
@@ -181,9 +181,9 @@ impl Args {
         info!("├─ Summary Text Prompt: {}...", config.summary_text_prompt.chars().take(50).collect::<String>());
         info!("├─ Summary Image Prompt: {}...", config.summary_image_prompt.chars().take(50).collect::<String>());
         info!("├─ Chat Messages Limit: {}", config.chat_messages_limit);
-        info!("├─ Chat Context Length: {}", config.chat_context_length);
+        info!("├─ Chat Max Context Length: {}", config.chat_max_context_length);
         info!("├─ Think Messages Limit: {}", config.think_messages_limit);
-        info!("├─ Think Context Length: {}", config.think_context_length);
+        info!("├─ Think Max Context Length: {}", config.think_max_context_length);
         info!("└─ Retrieve Limit: {}", config.retrieve_limit);
 
         Ok(config)

--- a/tools/discord/src/main.rs
+++ b/tools/discord/src/main.rs
@@ -203,14 +203,13 @@ impl Handler {
 
         let chat_response = author_ctx
             .send_and_wait_reply::<Chat, ChatMessages>(
-                ChatMessages {
-                    messages: conversation.clone(),
-                    restart: true,
-                    persist: false,
-                    stream: false,
-                    format: Some(format),
-                    tools: None,
-                },
+                ChatMessages::builder()
+                    .messages(conversation.clone())
+                    .restart(true)
+                    .persist(false)
+                    .stream(false)
+                    .format(format)
+                    .build(),
                 &self.chat,
                 SendOptions::builder().timeout(std::time::Duration::from_secs(600)).build(),
             )
@@ -244,14 +243,12 @@ impl Handler {
 
         let chat_response = author_ctx
             .send_and_wait_reply::<Chat, ChatMessages>(
-                ChatMessages {
-                    messages: conversation.clone(),
-                    restart: true,
-                    persist: false,
-                    stream: false,
-                    format: None,
-                    tools: None,
-                },
+                ChatMessages::builder()
+                    .messages(conversation.clone())
+                    .restart(true)
+                    .persist(false)
+                    .stream(false)
+                    .build(),
                 &self.chat,
                 SendOptions::builder().timeout(std::time::Duration::from_secs(600)).build(),
             )


### PR DESCRIPTION
Adds an option field to chat, think and ask request payloads so that these options can be set for llm generation.