### PR TITLE
Embedding Task Recovery & Health Check

### DIFF
--- a/bioma_rag/src/embeddings.rs
+++ b/bioma_rag/src/embeddings.rs
@@ -302,7 +302,7 @@ impl Message<TopK> for Embeddings {
             Query::Text(text) => {
                 match self.send_embedding_request(&EmbeddingContent::Text(vec![text.to_string()])).await {
                     Ok(embeddings) => embeddings.first().cloned().ok_or(EmbeddingsError::NoEmbeddingsGenerated)?,
-                    Err(EmbeddingsError::SendTextEmbeddings(_)) | Err(EmbeddingsError::RecvEmbeddings(_)) => {
+                    Err(EmbeddingsError::SendTextEmbeddings(_)) => {
                         warn!("{} Embedding task appears to have died, reinitializing...", ctx.id());
                         self.reinitialize(ctx).await?;
 
@@ -316,7 +316,7 @@ impl Message<TopK> for Embeddings {
             Query::Image(image_data) => {
                 match self.send_embedding_request(&EmbeddingContent::Image(vec![image_data.clone()])).await {
                     Ok(embeddings) => embeddings.first().cloned().ok_or(EmbeddingsError::NoEmbeddingsGenerated)?,
-                    Err(EmbeddingsError::SendTextEmbeddings(_)) | Err(EmbeddingsError::RecvEmbeddings(_)) => {
+                    Err(EmbeddingsError::SendTextEmbeddings(_)) => {
                         warn!("{} Embedding task appears to have died, reinitializing...", ctx.id());
                         self.reinitialize(ctx).await?;
 
@@ -356,7 +356,7 @@ impl Message<StoreEmbeddings> for Embeddings {
     async fn handle(&mut self, ctx: &mut ActorContext<Self>, message: &StoreEmbeddings) -> Result<(), EmbeddingsError> {
         let embeddings = match self.send_embedding_request(&message.content).await {
             Ok(embeddings) => embeddings,
-            Err(EmbeddingsError::SendTextEmbeddings(_)) | Err(EmbeddingsError::RecvEmbeddings(_)) => {
+            Err(EmbeddingsError::SendTextEmbeddings(_)) => {
                 warn!("{} Embedding task appears to have died, reinitializing...", ctx.id());
                 self.reinitialize(ctx).await?;
 
@@ -419,7 +419,7 @@ impl Message<GenerateEmbeddings> for Embeddings {
     ) -> Result<(), EmbeddingsError> {
         let embeddings = match self.send_embedding_request(&message.content).await {
             Ok(embeddings) => embeddings,
-            Err(EmbeddingsError::SendTextEmbeddings(_)) | Err(EmbeddingsError::RecvEmbeddings(_)) => {
+            Err(EmbeddingsError::SendTextEmbeddings(_)) => {
                 warn!("{} Embedding task appears to have died, reinitializing...", ctx.id());
                 self.reinitialize(ctx).await?;
 

--- a/tools/cognition/src/server.rs
+++ b/tools/cognition/src/server.rs
@@ -19,7 +19,8 @@ use bioma_tool::client::ListTools;
 use clap::Parser;
 use cognition::{
     health_check::{
-        check_markitdown, check_minio, check_ollama, check_pdf_analyzer, check_surrealdb, Responses, Service,
+        check_embeddings, check_markitdown, check_minio, check_ollama, check_pdf_analyzer, check_surrealdb, Responses,
+        Service,
     },
     ChatResponse, ToolHubMap, ToolsHub, UserActor,
 };
@@ -153,6 +154,9 @@ async fn health(data: web::Data<AppState>) -> impl Responder {
     // Minio health check
     let minio_url = Url::parse("http://127.0.0.1:9000").unwrap();
     services.insert(Service::Minio, check_minio(minio_url).await);
+
+    // Embeddings health check
+    services.insert(Service::Embeddings, check_embeddings(data.engine.clone(), data.embeddings.clone()).await);
 
     HttpResponse::Ok().json(services)
 }

--- a/tools/cognition/templates/rag_service_status.html
+++ b/tools/cognition/templates/rag_service_status.html
@@ -6,27 +6,27 @@
     <title>Service Health Dashboard</title>
     <style>
       :root {
+        /* Matching Bioma Dashboard styles */
         --primary: #ff00a0;
         --primary-hover: #e4008e;
-        --text-primary: #ffffff;
+        --text-primary: #f9fafb;
         --text-secondary: #e5e7eb;
-        --text-muted: #a0a0a0;
-        --bg-main: #121214;
+        --text-muted: #9ca3af;
+        --bg-main: #19191d;
         --bg-secondary: #1c1c1f;
-        --border-color: #2a2a2d;
-        --font-family: "JetBrains Mono", monospace;
-        --sidebar-width: 250px;
-        --sidebar-width-collapsed: 60px;
+        --border-color: #39393c;
+        --font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+          "Noto Color Emoji";
+        --transition-speed: 0.2s;
         --surrealist-gradient: linear-gradient(
           135deg,
           var(--primary) 0%,
           #9600ff 100%
         );
-      }
-
-      @font-face {
-        font-family: "JetBrains Mono";
-        src: url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap");
+        --surrealist-glow: 0 5px 20px -4px rgba(186, 0, 171, 0.4),
+          0 3px 15px rgba(186, 0, 171, 0.3);
       }
 
       html,
@@ -36,6 +36,8 @@
         background-color: var(--bg-main);
         color: var(--text-primary);
         font-family: var(--font-family);
+        overflow-x: hidden;
+        width: 100%;
       }
 
       .page-container {
@@ -44,100 +46,93 @@
         box-sizing: border-box;
         display: flex;
         flex-direction: column;
+        width: 100%;
+        overflow-x: hidden;
       }
 
       .status-title-container {
         text-align: center;
-        padding: 2rem;
+        padding: 1.5rem 0;
+        margin-bottom: 1.5rem;
         display: flex;
         justify-content: center;
         align-items: center;
       }
 
       .status-title {
-        font-size: 2.5rem;
-        font-weight: 700;
+        font-size: 2rem;
+        font-weight: 600;
         margin: 0;
-        color: white;
+        background: var(--surrealist-gradient);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
       }
 
       .services-container {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
         max-width: 1200px;
-        gap: 20px;
+        gap: 1.25rem;
         width: 100%;
         margin: 0 auto;
       }
 
       .service {
-        border: 2px solid var(--border-color);
-        border-radius: 12px;
-        padding: 20px;
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        padding: 1.5rem;
         text-align: center;
-        transition: transform 0.3s ease;
+        transition: all var(--transition-speed);
         height: 230px;
         display: flex;
         flex-direction: column;
         justify-content: center;
+        background-color: rgba(28, 28, 31, 0.6);
+        backdrop-filter: blur(8px);
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      }
+
+      .service:hover {
+        transform: translateY(-2px);
+        box-shadow: var(--surrealist-glow);
       }
 
       .error-container {
-        background-color: var(--error-bg);
-        border: 2px solid red;
-        color: white;
-        padding: 20px;
+        background-color: rgba(239, 68, 68, 0.15);
+        border: 1px solid rgba(239, 68, 68, 0.4);
+        color: #ef4444;
+        padding: 1.5rem;
         text-align: center;
-        border-radius: 12px;
+        border-radius: 0.75rem;
+        grid-column: 1 / -1;
       }
 
       .service.healthy {
-        background-color: rgba(0, 255, 0, 0.1);
-        border-color: rgba(0, 255, 0, 0.3);
+        background-color: rgba(16, 185, 129, 0.08);
+        border-color: rgba(16, 185, 129, 0.3);
       }
 
       .service.unhealthy {
-        background-color: rgba(255, 0, 0, 0.1);
-        border-color: rgba(255, 0, 0, 0.3);
+        background-color: rgba(239, 68, 68, 0.08);
+        border-color: rgba(239, 68, 68, 0.3);
       }
 
       .error-message {
-        background-color: rgba(255, 0, 0, 0.1);
-        border: 1px solid rgba(255, 0, 0, 0.3);
-        color: #ff6b6b;
-        padding: 12px;
-        border-radius: 12px;
-        margin-top: 15px;
+        background-color: rgba(239, 68, 68, 0.08);
+        border: 1px solid rgba(239, 68, 68, 0.3);
+        color: #ef4444;
+        padding: 0.75rem;
+        border-radius: 0.5rem;
+        margin-top: 0.75rem;
+        font-size: 0.875rem;
       }
 
       .health-info {
-        margin-top: 15px;
-        font-size: 0.8em;
+        margin-top: 0.75rem;
+        font-size: 0.875rem;
         color: var(--text-muted);
         word-break: break-all;
-      }
-
-      @media (max-width: 768px) {
-        .services-container {
-          grid-template-columns: 1fr 1fr;
-        }
-      }
-
-      @media (max-width: 480px) {
-        .services-container {
-          grid-template-columns: 1fr;
-        }
-      }
-
-      .last-updated {
-        color: #666;
-        font-size: 14px;
-      }
-
-      .last-updated {
-        color: #666;
-        font-size: 18px;
-        font-weight: bold;
       }
 
       .controls-bar {
@@ -146,29 +141,33 @@
         align-items: center;
         margin-bottom: 20px;
         padding: 10px 0;
-        border-bottom: 1px solid #39393c;
+        border-bottom: 1px solid var(--border-color);
         padding-left: 25px;
         padding-right: 25px;
+        box-sizing: border-box;
       }
 
       .refresh-button {
-        background: var(--bg-secondary);
+        background-color: var(--bg-secondary);
         border: 1px solid var(--border-color);
         color: var(--text-primary);
-        padding: 10px 15px;
-        border-radius: 5px;
+        padding: 0.5rem 1rem;
+        border-radius: 0.5rem;
         cursor: pointer;
-        height: 40px;
+        height: 2.5rem;
         display: flex;
         align-items: center;
         justify-content: center;
-        gap: 8px;
-        transition: all 0.2s;
+        gap: 0.5rem;
+        transition: all var(--transition-speed);
+        font-weight: 500;
+        font-size: 0.875rem;
       }
 
       .refresh-button:hover {
         background: var(--surrealist-gradient);
         border-color: var(--primary);
+        box-shadow: var(--surrealist-glow);
       }
 
       .refresh-button.active {
@@ -181,17 +180,78 @@
       }
 
       .refresh-button svg {
-        width: 16px;
-        height: 16px;
+        width: 1rem;
+        height: 1rem;
       }
 
       .last-updated {
-        color: #6b7280;
-        font-size: 14px;
+        color: var(--text-muted);
+        font-size: 0.875rem;
+        font-weight: 500;
       }
 
       .ollama-model {
-        font-size: 14px;
+        font-size: 0.875rem;
+        margin-top: 0.5rem;
+      }
+
+      .ollama-container {
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--border-color);
+      }
+
+      .service h3 {
+        margin-top: 0;
+        margin-bottom: 0.75rem;
+        font-weight: 600;
+        font-size: 1.125rem;
+        color: var(--text-primary);
+      }
+
+      .service p {
+        margin: 0.5rem 0;
+      }
+
+      .service p.status {
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.375rem;
+      }
+
+      .status-indicator {
+        display: inline-block;
+        width: 0.625rem;
+        height: 0.625rem;
+        border-radius: 50%;
+      }
+
+      .healthy .status-indicator {
+        background-color: #10b981;
+        box-shadow: 0 0 8px rgba(16, 185, 129, 0.6);
+      }
+
+      .unhealthy .status-indicator {
+        background-color: #ef4444;
+        box-shadow: 0 0 8px rgba(239, 68, 68, 0.6);
+      }
+
+      @media (max-width: 1024px) {
+        .services-container {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+
+      @media (max-width: 640px) {
+        .services-container {
+          grid-template-columns: 1fr;
+        }
+
+        .status-title {
+          font-size: 1.5rem;
+        }
       }
     </style>
   </head>
@@ -233,14 +293,9 @@
       const observer = new IntersectionObserver(
         (entries) => {
           entries.forEach((entry) => {
-            //("Intersection state:", entry.isIntersecting);
             if (entry.isIntersecting) {
-              //console.log("Container is visible, starting refresh");
-
               setupHealthStatusRefresh();
             } else {
-              //console.log("Container is hidden, clearing interval");
-
               if (window.healthInterval) {
                 window.clearInterval(window.healthInterval);
                 window.healthInterval = null;
@@ -288,12 +343,10 @@
       }
 
       async function fetchHealth() {
-        //console.log("Fetching health status...");
         try {
           // Verificar visibilidad antes de hacer el fetch
           const entry = await isElementVisible(container);
           if (!entry.isIntersecting) {
-            //console.log("Container not visible, skipping fetch");
             return;
           }
 
@@ -307,7 +360,6 @@
           }
 
           const data = await response.json();
-          //console.log("Health API Response:", data);
           container.innerHTML = "";
 
           // Orders the services alphabetically
@@ -316,8 +368,6 @@
           );
 
           for (const [name, info] of sortedEntries) {
-            //console.log(`Processing service: ${name}`, info);
-
             const div = document.createElement("div");
             div.className = `service ${
               info.is_healthy ? "healthy" : "unhealthy"
@@ -330,7 +380,6 @@
               info.is_healthy &&
               info.health?.models?.length > 0
             ) {
-              //console.log("Models found for Ollama:", info.health.models);
               let totalVram = 0;
 
               extraInfo += '<div class="ollama-container">';
@@ -371,7 +420,10 @@
             .replace(/_/g, " ")
             .toLowerCase()
             .replace(/\b\w/g, (char) => char.toUpperCase())}</h3>
-          <p>Status: ${info.is_healthy ? "Healthy" : "Unhealthy"}</p>
+          <p class="status">
+            <span class="status-indicator"></span>
+            ${info.is_healthy ? "Healthy" : "Unhealthy"}
+          </p>
           ${
             !info.is_healthy
               ? `<p class='error-message'>Error: ${info.error}</p>`
@@ -392,10 +444,8 @@
       }
 
       function setupHealthStatusRefresh() {
-        //console.log("Setting up health status refresh...");
         // Clear any existing intervals to prevent multiple timers
         if (window.healthInterval) {
-          //console.log("Clearing existing interval");
           window.clearInterval(window.healthInterval);
         }
 


### PR DESCRIPTION
## Overview
Added embedding task reinitialization and health check.

## Technical Details

### Automatic Reinitialization
When embedding requests fail with `EmbeddingsError::SendTextEmbeddings`, we now:
- Log a warning that the task appears to have died
- Call `self.reinitialize(ctx)` to clean up references and restart the task
- Retry the original request with the new task

```rust
// If sending fails with SendTextEmbeddings error
Err(EmbeddingsError::SendTextEmbeddings(_)) => {
    warn!("{} Embedding task appears to have died, reinitializing...", ctx.id());
    self.reinitialize(ctx).await?;
    self.send_embedding_request(&message.content).await?
}
```

### Health Check
Added a `Health` message type with corresponding handler that checks if the embedding task is alive:

```rust
impl Message<Health> for Embeddings {
    type Response = Status;

    async fn handle(&mut self, ctx: &mut ActorContext<Self>, _message: &Health) -> Result<(), EmbeddingsError> {
        let is_alive = match self.send_heartbeat().await {
            Ok(_) => Status::Alive,
            Err(e) => Status::Dead(e.to_string()),
        };
        ctx.reply(is_alive).await?;
        Ok(())
    }
}
```

The status check sends a lightweight `Heartbeat` message through the channel to verify task health.