### PR TITLE
Fix sub/unsub for filesys

### DIFF
--- a/bioma_mcp/examples/mcp_client.rs
+++ b/bioma_mcp/examples/mcp_client.rs
@@ -187,6 +187,20 @@ async fn main() -> Result<()> {
                         }
 
                         info!("Trying to subscribe to filesystem changes...");
+                        let filesystem_uri = "file:///mcp_server.log";
+                        match client.subscribe_resource(filesystem_uri.to_string()).await {
+                            Ok(_) => info!("Successfully subscribed to filesystem changes at {}", filesystem_uri),
+                            Err(e) => error!("Failed to subscribe to filesystem changes: {:?}", e),
+                        }
+
+                        // Wait a moment to receive any potential change notifications
+                        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+                        // Unsubscribe from filesystem changes
+                        match client.unsubscribe_resource(filesystem_uri.to_string()).await {
+                            Ok(_) => info!("Successfully unsubscribed from filesystem changes"),
+                            Err(e) => error!("Failed to unsubscribe from filesystem changes: {:?}", e),
+                        }
                     }
                     Err(e) => info!("Resource templates not supported: {:?}", e),
                 }

--- a/bioma_mcp/examples/mcp_client.rs
+++ b/bioma_mcp/examples/mcp_client.rs
@@ -192,11 +192,7 @@ async fn main() -> Result<()> {
                             Ok(_) => info!("Successfully subscribed to filesystem changes at {}", filesystem_uri),
                             Err(e) => error!("Failed to subscribe to filesystem changes: {:?}", e),
                         }
-
-                        // Wait a moment to receive any potential change notifications
-                        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
-                        // Unsubscribe from filesystem changes
+                        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
                         match client.unsubscribe_resource(filesystem_uri.to_string()).await {
                             Ok(_) => info!("Successfully unsubscribed from filesystem changes"),
                             Err(e) => error!("Failed to unsubscribe from filesystem changes: {:?}", e),

--- a/bioma_mcp/src/resources/mod.rs
+++ b/bioma_mcp/src/resources/mod.rs
@@ -36,7 +36,7 @@ pub trait ResourceReadHandler: Send + Sync {
     fn def(&self) -> Resource;
 
     fn supports(&self, uri: &str) -> bool {
-        self.def().uri == uri
+        uri.starts_with(&self.def().uri)
     }
 
     fn templates(&self) -> Vec<ResourceTemplate> {
@@ -115,7 +115,7 @@ impl<T: ResourceDef + Send + Sync> ResourceReadHandler for T {
     }
 
     fn supports(&self, uri: &str) -> bool {
-        self.def().uri == uri
+        uri.starts_with(&self.def().uri)
     }
 
     fn templates(&self) -> Vec<ResourceTemplate> {


### PR DESCRIPTION
- **filesys**
- **validate on starts with, not exact match**
- **mcp client sub and unsub example**
